### PR TITLE
feat: create and submit v2 aind-data-transfer-service jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "wavpack-numcodecs<0.2",
     "cryptography<43.0",
     "aind-data-transfer-models>=0.15.0",
+    "aind-data-transfer-service>=1.14.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dependencies = [
     "npc-ephys>=0.1.32",
     "wavpack-numcodecs<0.2",
     "cryptography<43.0",
-    "aind-data-transfer-models>=0.15.0",
     "aind-data-transfer-service>=1.14.0",
 ]
 requires-python = ">=3.10"
@@ -93,7 +92,6 @@ dev = [
 dynamicrouting = [
     "npc-lims>=0.1.154",
     "npc-sessions>=0.0.253",
-    "aind-data-transfer-models>=0.13.1",
     "aind-codeocean-pipeline-monitor[full]>=0.5.0",
     "aind-metadata-mapper==0.18.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "wavpack-numcodecs<0.2",
     "cryptography<43.0",
     "aind-data-transfer-service>=1.15.0",
-    "aind-slurm-rest>=0.1.0,<0.2.1",
+    "aind-slurm-rest-v2==0.0.3",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ upload_dr_behavior = "np_codeocean.scripts.upload_dynamic_routing_behavior:main"
 upload_dr_ecephys = "np_codeocean.scripts.upload_dynamic_routing_ecephys:main"
 upload_sessions = "np_codeocean.scripts.upload_sessions:main"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "bump>=1.3.2",
     "pdm>=2.4.9",
@@ -96,6 +96,13 @@ dynamicrouting = [
     "npc-sessions>=0.0.253",
     "aind-codeocean-pipeline-monitor[full]>=0.5.0",
     "aind-metadata-mapper==0.18.2",
+]
+
+[tool.uv]
+package = true
+default-groups = [
+    "dev",
+    "dynamicrouting",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ dependencies = [
     "npc-ephys>=0.1.32",
     "wavpack-numcodecs<0.2",
     "cryptography<43.0",
-    "aind-data-transfer-service>=1.14.0",
+    "aind-data-transfer-service>=1.15.0",
+    "aind-slurm-rest>=0.1.0,<0.2.1",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
     "cryptography<43.0",
     "aind-data-transfer-service>=1.15.0",
     "aind-slurm-rest-v2==0.0.3",
+    "aind-codeocean-pipeline-monitor>=0.5.2",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/np_codeocean/np_session_utils.py
+++ b/src/np_codeocean/np_session_utils.py
@@ -183,13 +183,13 @@ def get_surface_channel_start_time(session: np_session.Session) -> datetime.date
     return timestamp
 
 
-def get_v2_upload_params_from_session(upload: CodeOceanUpload) -> dict[str, str | int | bool]:
+def get_upload_params_from_session(upload: CodeOceanUpload) -> dict[str, Any]:
     """
     >>> path = "//allen/programs/mindscope/workgroups/dynamicrouting/PilotEphys/Task 2 pilot/DRpilot_690706_20231129_surface_channels"
     >>> utils.is_surface_channel_recording(path)
     True
     >>> upload = create_codeocean_upload(path)
-    >>> ephys_upload_params = get_v2_upload_params_from_session(upload)
+    >>> ephys_upload_params = get_upload_params_from_session(upload)
     >>> ephys_upload_params['modalities']['ecephys']
     '//allen/programs/mindscope/workgroups/np-exp/codeocean/DRpilot_690706_20231129_surface_channels/ephys'
     >>> ephys_upload_params.keys()
@@ -209,6 +209,7 @@ def get_v2_upload_params_from_session(upload: CodeOceanUpload) -> dict[str, str 
     }.items():
         if getattr(upload, attr_name) is not None:
             modalities[modality_abbr] = np_config.normalize_path(getattr(upload, attr_name)).as_posix()
+
     if upload.aind_metadata:
         params['metadata_dir'] = upload.aind_metadata.as_posix()
             
@@ -217,49 +218,6 @@ def get_v2_upload_params_from_session(upload: CodeOceanUpload) -> dict[str, str 
         params['acq_datetime'] = date.combine(upload.session.date, get_surface_channel_start_time(upload.session).time())
     else:
         params['acq_datetime'] = upload.session.start
-    return params # type: ignore
-
-
-@typing_extensions.deprecated("Creates old, pre-v2 csv: use get_upload_csv_for_session_v2")
-def get_upload_csv_for_session(upload: CodeOceanUpload) -> dict[str, str | int | bool]:
-    """
-    >>> path = "//allen/programs/mindscope/workgroups/dynamicrouting/PilotEphys/Task 2 pilot/DRpilot_690706_20231129_surface_channels"
-    >>> utils.is_surface_channel_recording(path)
-    True
-    >>> upload = create_codeocean_upload(path)
-    >>> ephys_upload_csv = get_upload_csv_for_session(upload)
-    >>> ephys_upload_csv['modality0.source']
-    '//allen/programs/mindscope/workgroups/np-exp/codeocean/DRpilot_690706_20231129_surface_channels/ephys'
-    >>> ephys_upload_csv.keys()
-    dict_keys(['project_name', 'platform', 'subject-id', 'force_cloud_sync', 'modality0', 'modality0.source', 'acq-datetime'])
-    """
-    params = {
-        'project_name': upload.project_name,
-        'platform': upload.platform,
-        'subject-id': str(upload.session.mouse),
-        'force_cloud_sync': upload.force_cloud_sync,
-    }
-    idx = 0
-    for modality_name, attr_name in {
-        'ecephys': 'ephys',
-        'behavior': 'behavior',
-        'behavior-videos': 'behavior_videos',
-    }.items():
-        if getattr(upload, attr_name) is not None:
-            params[f'modality{idx}'] = modality_name
-            params[f'modality{idx}.source'] = np_config.normalize_path(getattr(upload, attr_name)).as_posix()
-            idx += 1
-    
-    if upload.aind_metadata:
-        params['metadata_dir'] = upload.aind_metadata.as_posix()
-            
-    if utils.is_surface_channel_recording(upload.session.npexp_path.as_posix()):
-        date = datetime.datetime(upload.session.date.year, upload.session.date.month, upload.session.date.day)
-        session_date_time = date.combine(upload.session.date, get_surface_channel_start_time(upload.session).time())
-        params['acq-datetime'] = f'{session_date_time.strftime(utils.ACQ_DATETIME_FORMAT)}'
-    else:
-        params['acq-datetime'] = f'{upload.session.start.strftime(utils.ACQ_DATETIME_FORMAT)}'
-    
     return params # type: ignore
 
 
@@ -334,8 +292,7 @@ def has_metadata(session: np_session.Session) -> bool:
 def get_aind_metadata_path(upload_root: pathlib.Path) -> pathlib.Path:
     return np_config.normalize_path(upload_root / 'aind_metadata')
 
-
-def upload_session_v2(
+def upload_session(
     session_path_or_folder_name: str, 
     recording_dirs: Iterable[str] | None = None,
     force: bool = False,
@@ -395,87 +352,8 @@ def upload_session_v2(
         if 'codeocean_configs' in extra_UploadJobConfigsV2_params:
             raise ValueError("Cannot pass `codeocean_configs` as a parameter to `extra_UploadJobConfigsV2_params`")
         extra_UploadJobConfigsV2_params['codeocean_configs'] = codeocean_configs
-    utils.put_v2_jobs_for_hpc_upload(
-        utils.create_upload_job_configs_v2(**job_params, check_timestamps=timestamps_adjusted, **extra_UploadJobConfigsV2_params),
-        upload_service_url=utils.DEV_SERVICE if test else utils.AIND_DATA_TRANSFER_SERVICE,
-        user_email=hpc_upload_job_email,
-        dry_run=dry_run,
-        save_path=upload.job.with_suffix('.json'),
-    )
-    if not dry_run:
-        logger.info(f'Finished submitting {upload.session} - check progress at {utils.DEV_SERVICE if test else utils.AIND_DATA_TRANSFER_SERVICE}')
-    
-    if (is_split_recording := 
-        recording_dirs is not None 
-        and len(tuple(recording_dirs)) > 1 
-        and isinstance(recording_dirs, str)
-    ):
-        logger.warning(f"Split recording {upload.session} will need to be sorted manually with `CONCAT=True`")
-
-
-@typing_extensions.deprecated("Uses old, pre-v2 endpoints: use upload_session-v2")
-def upload_session(
-    session_path_or_folder_name: str, 
-    recording_dirs: Iterable[str] | None = None,
-    force: bool = False,
-    dry_run: bool = False,
-    test: bool = False,
-    hpc_upload_job_email: str = utils.HPC_UPLOAD_JOB_EMAIL,
-    regenerate_symlinks: bool = True,
-    adjust_ephys_timestamps: bool = True,
-    codeocean_configs: aind_data_transfer_models.core.CodeOceanPipelineMonitorConfigs | None = None,
-    extra_BasicUploadJobConfigs_params: dict[str, Any] | None = None,
-) -> None:
-    codeocean_root = np_session.NPEXP_PATH / ('codeocean-dev' if test else 'codeocean')
-    logger.debug(f'{codeocean_root = }')
-    upload = create_codeocean_upload(
-        str(session_path_or_folder_name),
-        codeocean_root=codeocean_root,
-        recording_dirs=recording_dirs,
-        force_cloud_sync=force
-    )
-    if regenerate_symlinks and upload.root.exists():
-        logger.debug(f'Removing existing {upload.root = }')
-        shutil.rmtree(upload.root.as_posix(), ignore_errors=True)
-    if upload.aind_metadata:
-        create_aind_metadata_symlinks(upload)
-    if upload.ephys:
-        create_ephys_symlinks(upload.session, upload.ephys, recording_dirs=recording_dirs)
-    if upload.behavior:
-        create_behavior_symlinks(upload.session, upload.behavior)
-    if upload.behavior_videos:
-        create_behavior_videos_symlinks(upload.session, upload.behavior_videos)
-    timestamps_adjusted = False
-    if adjust_ephys_timestamps and upload.ephys:
-        if not upload.behavior: # includes surface channel recordings
-            logger.warning(f"Cannot adjust ephys timestamps for {upload.session} - no behavior folder supplied for upload")
-        else:
-            try:
-                utils.write_corrected_ephys_timestamps(ephys_dir=upload.ephys, behavior_dir=upload.behavior)
-            except utils.SyncFileNotFoundError:
-                raise FileNotFoundError(
-                    (
-                        f"Cannot adjust timestamps - no sync file found in {upload.behavior}. "
-                        "If the session doesn't have one, run with "
-                        "`adjust_ephys_timestamps=False` or `--no-sync` flag in CLI"
-                    )
-                ) from None
-            else:
-                timestamps_adjusted = True
-    for path in (upload.ephys, upload.behavior, upload.behavior_videos, upload.aind_metadata):
-        if path is not None and path.exists():
-            utils.convert_symlinks_to_posix(path)
-    csv_content: dict = get_upload_csv_for_session(upload)
-    utils.write_upload_csv(csv_content, upload.job)
-    np_logging.web('np_codeocean').info(f'Submitting {upload.session} to hpc upload queue')
-    if extra_BasicUploadJobConfigs_params is None:
-        extra_BasicUploadJobConfigs_params = {}
-    if codeocean_configs is not None:
-        if 'codeocean_configs' in extra_BasicUploadJobConfigs_params:
-            raise ValueError("Cannot pass `codeocean_configs` as a parameter to `extra_BasicUploadJobConfigs_params`")
-        extra_BasicUploadJobConfigs_params['codeocean_configs'] = codeocean_configs
     utils.put_jobs_for_hpc_upload(
-        utils.get_job_models_from_csv(upload.job, check_timestamps=timestamps_adjusted, **extra_BasicUploadJobConfigs_params),
+        utils.create_upload_job_configs_v2(**job_params, check_timestamps=timestamps_adjusted, **extra_UploadJobConfigsV2_params),
         upload_service_url=utils.DEV_SERVICE if test else utils.AIND_DATA_TRANSFER_SERVICE,
         user_email=hpc_upload_job_email,
         dry_run=dry_run,

--- a/src/np_codeocean/np_session_utils.py
+++ b/src/np_codeocean/np_session_utils.py
@@ -358,6 +358,7 @@ def upload_session(
             **job_params_from_session,
             codeocean_pipeline_settings=codeocean_pipeline_settings,
             check_timestamps=timestamps_adjusted,
+            test=test,
             **extra_UploadJobConfigsV2_params
         ),
         upload_service_url=utils.DEV_SERVICE if test else utils.AIND_DATA_TRANSFER_SERVICE,

--- a/src/np_codeocean/scripts/upload_dynamic_routing_behavior.py
+++ b/src/np_codeocean/scripts/upload_dynamic_routing_behavior.py
@@ -265,6 +265,7 @@ def upload(
             metadata_dir=np_config.normalize_path(metadata_dir).as_posix(),
             force_cloud_sync=force_cloud_sync,
             user_email=hpc_upload_job_email,
+            test=test,
         ),
         upload_service_url=upload_service_url,
         user_email=hpc_upload_job_email,

--- a/src/np_codeocean/scripts/upload_dynamic_routing_behavior.py
+++ b/src/np_codeocean/scripts/upload_dynamic_routing_behavior.py
@@ -253,7 +253,7 @@ def upload(
     acq_datetime_str = npc_session.extract_isoformat_datetime(task_source.stem)
     if not acq_datetime_str:
         raise SessionNotUploadedError(f"Could not extract acquisition datetime from {task_source.stem}")
-    np_codeocean.utils.put_v2_jobs_for_hpc_upload(
+    np_codeocean.utils.put_jobs_for_hpc_upload(
         upload_jobs=np_codeocean.utils.create_upload_job_configs_v2(
             subject_id=str(extracted_subject_id),
             acq_datetime=datetime.datetime.fromisoformat(acq_datetime_str),

--- a/src/np_codeocean/scripts/upload_dynamic_routing_ecephys.py
+++ b/src/np_codeocean/scripts/upload_dynamic_routing_ecephys.py
@@ -184,7 +184,7 @@ def write_metadata_and_upload(
         pipeline_monitor_capsule_settings=pipelines,
     )
     
-    return np_codeocean.upload_session(
+    return np_codeocean.upload_session_v2(
         session_path_or_folder_name,
         recording_dirs=recording_dirs,
         force=force,
@@ -193,7 +193,7 @@ def write_metadata_and_upload(
         hpc_upload_job_email=hpc_upload_job_email,
         regenerate_symlinks=regenerate_symlinks,
         adjust_ephys_timestamps=adjust_ephys_timestamps,
-        extra_BasicUploadJobConfigs_params={
+        extra_UploadJobConfigsV2_params={
             'codeocean_configs': codeocean_configs,
         },
     )

--- a/src/np_codeocean/scripts/upload_dynamic_routing_ecephys.py
+++ b/src/np_codeocean/scripts/upload_dynamic_routing_ecephys.py
@@ -184,7 +184,7 @@ def write_metadata_and_upload(
         pipeline_monitor_capsule_settings=pipelines,
     )
     
-    return np_codeocean.upload_session_v2(
+    return np_codeocean.upload_session(
         session_path_or_folder_name,
         recording_dirs=recording_dirs,
         force=force,

--- a/src/np_codeocean/scripts/upload_split_recordings_example.py
+++ b/src/np_codeocean/scripts/upload_split_recordings_example.py
@@ -23,11 +23,11 @@ session_folders_to_upload: set[str] = set([
 
 def main() -> None:
     for session_folder in session_folders_to_upload - split_recording_folders:
-        np_codeocean.upload_session(session_folder)
+        np_codeocean.upload_session_v2(session_folder)
         
     for session_folder, recording_dir_names in split_recordings.items():
         if recording_dir_names:
-            np_codeocean.upload_session(session_folder, recording_dir_names)
+            np_codeocean.upload_session_v2(session_folder, recording_dir_names)
         
 if __name__ == '__main__':
     main()    

--- a/src/np_codeocean/scripts/upload_split_recordings_example.py
+++ b/src/np_codeocean/scripts/upload_split_recordings_example.py
@@ -23,11 +23,11 @@ session_folders_to_upload: set[str] = set([
 
 def main() -> None:
     for session_folder in session_folders_to_upload - split_recording_folders:
-        np_codeocean.upload_session_v2(session_folder)
+        np_codeocean.upload_session(session_folder)
         
     for session_folder, recording_dir_names in split_recordings.items():
         if recording_dir_names:
-            np_codeocean.upload_session_v2(session_folder, recording_dir_names)
+            np_codeocean.upload_session(session_folder, recording_dir_names)
         
 if __name__ == '__main__':
     main()    

--- a/src/np_codeocean/utils.py
+++ b/src/np_codeocean/utils.py
@@ -357,8 +357,13 @@ def create_upload_job_configs_v2(
             job_settings=job_settings,
             image_resources=slurm_settings,
         )
+    # The job_type contains the default settings for compression and Code Ocean pipelines.
+    # For now, use "ecephys" job_type to compress ecephys data by default.
+    if job_type == "default" and Modality.ECEPHYS.abbreviation in modality_transformation_settings_tasks:
+        job_type = "ecephys"
     # Code Ocean pipeline settings
-    # You can specify up to one pipeline conf per modality
+    # You can manually specify up to one pipeline conf per modality.
+    # These will override any pipelines defined by the job_type.
     # In the future, these can be stored in AWS param store as part of a "job_type"
     codeocean_pipeline_settings_tasks = dict() # {modality_abbr: Task}
     if codeocean_pipeline_settings is not None:

--- a/src/np_codeocean/utils.py
+++ b/src/np_codeocean/utils.py
@@ -304,6 +304,48 @@ def write_upload_csv(
         w.writerow(content.values())
     return output_path
 
+def get_job_models_from_csv_v2(
+    path: pathlib.Path,
+    ephys_slurm_settings: aind_slurm_rest.models.V0036JobProperties = DEFAULT_EPHYS_SLURM_SETTINGS,
+    check_timestamps: bool = True, # default in transfer service is True: checks timestamps have been corrected via flag file
+    user_email: str = HPC_UPLOAD_JOB_EMAIL,
+    **extra_BasicUploadJobConfigs_params: Any,
+) -> tuple[aind_data_transfer_models.core.BasicUploadJobConfigs, ...]:
+    jobs = pl.read_csv(path, eol_char='\r').with_columns(
+        pl.col('subject-id').cast(str),
+    ).to_dicts()
+    jobs = jobs
+    models = []
+    for job in jobs.copy():
+        modalities = []
+        if 'modalities' in extra_BasicUploadJobConfigs_params:
+            raise ValueError('modalities should not be passed as a parameter in extra_BasicUploadJobConfigs_params')
+        for modality_column in (k for k in job.keys() if k.startswith('modality') and ".source" not in k):
+            modality_name = job[modality_column]
+            modalities.append(
+                aind_data_transfer_models.core.ModalityConfigs(
+                    modality=modality_name,
+                    source=job[f"{modality_column}.source"],
+                    slurm_settings=ephys_slurm_settings if modality_name == 'ecephys' else None,
+                    job_settings={'check_timestamps': False} if modality_name == 'ecephys' and not check_timestamps else None,
+                ),
+            )
+        for k in (k for k in job.copy().keys() if k.startswith('modality')):
+            del job[k]
+        for k, v in job.items():
+            if isinstance(v, str) and '\n' in v:
+                job[k] = v.replace('\n', '')
+        models.append(
+            aind_data_transfer_models.core.BasicUploadJobConfigs(
+                **{k.replace('-', '_'): v for k,v in job.items()},
+                modalities=modalities,
+                user_email=user_email,
+                **extra_BasicUploadJobConfigs_params,
+            )
+        )
+    return tuple(models)
+
+@typing_extensions.deprecated("Assumes old, pre-v2 csv: use get_job_models_from_csv_v2")
 def get_job_models_from_csv(
     path: pathlib.Path,
     ephys_slurm_settings: aind_slurm_rest.models.V0036JobProperties = DEFAULT_EPHYS_SLURM_SETTINGS,
@@ -345,6 +387,49 @@ def get_job_models_from_csv(
         )
     return tuple(models)
 
+def put_jobs_for_hpc_upload_v2(
+    upload_jobs: aind_data_transfer_models.core.BasicUploadJobConfigs | Iterable[aind_data_transfer_models.core.BasicUploadJobConfigs],
+    upload_service_url: str = AIND_DATA_TRANSFER_SERVICE,
+    user_email: str = HPC_UPLOAD_JOB_EMAIL,
+    email_notification_types: Iterable[str | aind_data_transfer_models.core.EmailNotificationType] = ('fail',),
+    dry_run: bool = False,
+    save_path: pathlib.Path | None = None,
+    **extra_model_kwargs: Any,
+) -> None:
+    """Submit one or more jobs to the aind-data-transfer-service, for
+    upload to S3 on the hpc.
+    
+    - accepts one or more aind_data_schema BasicUploadJobConfigs models
+    - assembles a SubmitJobRequest model
+    - excludes jobs for sessions that are already in the upload queue
+    - accepts additional parameters for SubmitHpcJobRequest as kwargs
+    - submits json via http request
+    - optionally saves the json file as a record
+    """
+    if not isinstance(upload_jobs, Iterable):
+        upload_jobs = (upload_jobs, )
+    submit_request = aind_data_transfer_models.core.SubmitJobRequest(
+        upload_jobs=[job for job in upload_jobs if not is_job_in_hpc_upload_queue(job)],
+        user_email=user_email,
+        email_notification_types=email_notification_types,
+        **extra_model_kwargs,
+    )
+    post_request_content = json.loads(
+        submit_request.model_dump_json(round_trip=True, exclude_none=True)
+    ) #! round_trip required for s3 bucket suffix to work correctly
+    if save_path:
+        save_path.write_text(submit_request.model_dump_json(round_trip=True, indent=4), errors='ignore')
+    if dry_run:
+        logger.warning(f'Dry run: not submitting {len(upload_jobs)} upload job(s) to {upload_service_url}')
+        return
+    post_json_response: requests.Response = requests.post(
+        url=f"{upload_service_url}/api/v1/submit_jobs",
+        json=post_request_content,
+    )
+    logger.info(f"Submitted {len(upload_jobs)} upload job(s) to {upload_service_url}")
+    post_json_response.raise_for_status()
+
+@typing_extensions.deprecated("Uses old, pre-v2 endpoints: use put_jobs_for_hpc_upload_v2 in combination with get_job_models_from_csv")
 def put_jobs_for_hpc_upload(
     upload_jobs: aind_data_transfer_models.core.BasicUploadJobConfigs | Iterable[aind_data_transfer_models.core.BasicUploadJobConfigs],
     upload_service_url: str = AIND_DATA_TRANSFER_SERVICE,
@@ -387,7 +472,7 @@ def put_jobs_for_hpc_upload(
     logger.info(f"Submitted {len(upload_jobs)} upload job(s) to {upload_service_url}")
     post_json_response.raise_for_status()
 
-@typing_extensions.deprecated("Uses old, pre-v1 endpoints: use put_jobs_for_hpc_upload in combination with get_job_models_from_csv")
+@typing_extensions.deprecated("Uses old, pre-v1 endpoints: use put_jobs_for_hpc_upload_v2 in combination with get_job_models_from_csv_v2")
 def put_csv_for_hpc_upload(
     csv_path: pathlib.Path,
     upload_service_url: str = AIND_DATA_TRANSFER_SERVICE,

--- a/uv.lock
+++ b/uv.lock
@@ -115,25 +115,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aind-data-transfer-models"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aind-codeocean-pipeline-monitor" },
-    { name = "aind-data-schema-models" },
-    { name = "aind-metadata-mapper" },
-    { name = "aind-slurm-rest" },
-    { name = "codeocean" },
-    { name = "email-validator" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/64/02ab3354044f4ad90b2a37efbb5a94282a4d9b23c4cc7ee629bdefede396/aind_data_transfer_models-0.15.0.tar.gz", hash = "sha256:13ed5e15bfd5b4cbf5f8926b0b5e9099c75a6a1d69ba2113570d3252305d9900", size = 48443 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/51/629e0309c71fee63edcfd13ba0cb394843d28ac5be713f88c3ccf9e30b46/aind_data_transfer_models-0.15.0-py3-none-any.whl", hash = "sha256:1f2c9c116d938337a392e70cd3c41b6e0b164a44df36806a16d010b87fdb3dbd", size = 14012 },
-]
-
-[[package]]
 name = "aind-data-transfer-service"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -174,21 +155,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/6d/a3c61ea41e6b79f0f2369599166fd6a6c9fc57283bf2b54821ee69377e71/aind_session-0.3.13.tar.gz", hash = "sha256:3d41465c19fe6c5f0f0c51ce7575a02031adad674f252915d365635c35ed5b66", size = 41640 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/fd/27f35db444fa4642d4e052c5630818f6d423a58c921a0e8a1684e3751895/aind_session-0.3.13-py3-none-any.whl", hash = "sha256:6323140080157ec44039d1289e037ab1edfbb69eb9a446258af8c8237d852ecc", size = 44901 },
-]
-
-[[package]]
-name = "aind-slurm-rest"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dateutil" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/32/7c/83bba0ee13f01c17067d5ec2d12bec8a2cf0f64b2d1bbfb9a7850e2d5771/aind_slurm_rest-0.2.0.tar.gz", hash = "sha256:d1a45e8c3e6c2e08b71830997675ba541fe145d0121f1ac70eecccc5792ab7e3", size = 148349 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/cb/afc40da5e56d420f1c0a59f561642bda77f6cee7383f04762bb4f359b5c0/aind_slurm_rest-0.2.0-py3-none-any.whl", hash = "sha256:c80b2ef3746d3532619a0aff00a42da6f08fe1462c214d00dd281ce91acdea1c", size = 358939 },
 ]
 
 [[package]]
@@ -2026,7 +1992,6 @@ name = "np-codeocean"
 version = "0.3.3"
 source = { editable = "." }
 dependencies = [
-    { name = "aind-data-transfer-models" },
     { name = "aind-data-transfer-service" },
     { name = "cryptography" },
     { name = "np-config" },
@@ -2047,7 +2012,6 @@ dev = [
 ]
 dynamicrouting = [
     { name = "aind-codeocean-pipeline-monitor", extra = ["full"] },
-    { name = "aind-data-transfer-models" },
     { name = "aind-metadata-mapper" },
     { name = "npc-lims" },
     { name = "npc-sessions" },
@@ -2056,8 +2020,6 @@ dynamicrouting = [
 [package.metadata]
 requires-dist = [
     { name = "aind-codeocean-pipeline-monitor", extras = ["full"], marker = "extra == 'dynamicrouting'", specifier = ">=0.5.0" },
-    { name = "aind-data-transfer-models", specifier = ">=0.15.0" },
-    { name = "aind-data-transfer-models", marker = "extra == 'dynamicrouting'", specifier = ">=0.13.1" },
     { name = "aind-data-transfer-service", specifier = ">=1.14.0" },
     { name = "aind-metadata-mapper", marker = "extra == 'dynamicrouting'", specifier = "==0.18.2" },
     { name = "bump", marker = "extra == 'dev'", specifier = ">=1.3.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -116,7 +116,7 @@ wheels = [
 
 [[package]]
 name = "aind-data-transfer-service"
-version = "1.14.0"
+version = "1.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aind-data-schema-models" },
@@ -124,9 +124,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/ae/1aadf237726ac401ea8db334d7ad060b1e8736f860df0a9bee6ce5e31e81/aind_data_transfer_service-1.14.0.tar.gz", hash = "sha256:6bc36cde8876f4bb10a79bc9b8397f6360c7da2c7a27b363bf1d9ed9f7fa4b4b", size = 216418 }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/62/0a88002ddc59a7009c03bee3b2b1b5281ea48dfe85806f370468c7698ecf/aind_data_transfer_service-1.15.0.tar.gz", hash = "sha256:9b9ccac8fb7c401a85da318e5e1712c0a2eb5f8faf1cb347d9cc1dad95117c98", size = 219527 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/67/cae2bc324fbd77e6852effd3f0ec74f26ae98a1d1926b163f4c74a86787a/aind_data_transfer_service-1.14.0-py3-none-any.whl", hash = "sha256:1ad574302b51353f249f04f09cb8cf0045caee528b7c637ded71c7ccfc9731f1", size = 45367 },
+    { url = "https://files.pythonhosted.org/packages/75/e1/d19d8f2bc54a538da93c1cbb798102cb8ae23954596ea6e2a2c1803034a4/aind_data_transfer_service-1.15.0-py3-none-any.whl", hash = "sha256:92bdf8bdc1a852e039071b9d85b7a2212d9bc3aeef2e74b9539eab765afae655", size = 47073 },
 ]
 
 [[package]]
@@ -155,6 +155,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/6d/a3c61ea41e6b79f0f2369599166fd6a6c9fc57283bf2b54821ee69377e71/aind_session-0.3.13.tar.gz", hash = "sha256:3d41465c19fe6c5f0f0c51ce7575a02031adad674f252915d365635c35ed5b66", size = 41640 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/fd/27f35db444fa4642d4e052c5630818f6d423a58c921a0e8a1684e3751895/aind_session-0.3.13-py3-none-any.whl", hash = "sha256:6323140080157ec44039d1289e037ab1edfbb69eb9a446258af8c8237d852ecc", size = 44901 },
+]
+
+[[package]]
+name = "aind-slurm-rest"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/7c/83bba0ee13f01c17067d5ec2d12bec8a2cf0f64b2d1bbfb9a7850e2d5771/aind_slurm_rest-0.2.0.tar.gz", hash = "sha256:d1a45e8c3e6c2e08b71830997675ba541fe145d0121f1ac70eecccc5792ab7e3", size = 148349 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/cb/afc40da5e56d420f1c0a59f561642bda77f6cee7383f04762bb4f359b5c0/aind_slurm_rest-0.2.0-py3-none-any.whl", hash = "sha256:c80b2ef3746d3532619a0aff00a42da6f08fe1462c214d00dd281ce91acdea1c", size = 358939 },
 ]
 
 [[package]]
@@ -1993,6 +2008,7 @@ version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "aind-data-transfer-service" },
+    { name = "aind-slurm-rest" },
     { name = "cryptography" },
     { name = "np-config" },
     { name = "np-session" },
@@ -2020,8 +2036,9 @@ dynamicrouting = [
 [package.metadata]
 requires-dist = [
     { name = "aind-codeocean-pipeline-monitor", extras = ["full"], marker = "extra == 'dynamicrouting'", specifier = ">=0.5.0" },
-    { name = "aind-data-transfer-service", specifier = ">=1.14.0" },
+    { name = "aind-data-transfer-service", specifier = ">=1.15.0" },
     { name = "aind-metadata-mapper", marker = "extra == 'dynamicrouting'", specifier = "==0.18.2" },
+    { name = "aind-slurm-rest", specifier = ">=0.1.0,<0.2.1" },
     { name = "bump", marker = "extra == 'dev'", specifier = ">=1.3.2" },
     { name = "cryptography", specifier = "<43.0" },
     { name = "np-config", specifier = ">=0.4.33" },

--- a/uv.lock
+++ b/uv.lock
@@ -158,8 +158,8 @@ wheels = [
 ]
 
 [[package]]
-name = "aind-slurm-rest"
-version = "0.2.0"
+name = "aind-slurm-rest-v2"
+version = "0.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -167,9 +167,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/7c/83bba0ee13f01c17067d5ec2d12bec8a2cf0f64b2d1bbfb9a7850e2d5771/aind_slurm_rest-0.2.0.tar.gz", hash = "sha256:d1a45e8c3e6c2e08b71830997675ba541fe145d0121f1ac70eecccc5792ab7e3", size = 148349 }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/81/e21e8dc98d597d945b25249d732e2dc2dcf235c868b67cf4df585901c776/aind_slurm_rest_v2-0.0.3.tar.gz", hash = "sha256:e11645c2e5ce4f78a7ec1dbe462caf10a8bd1a6efe560af21935e98eea119e3f", size = 430840 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/cb/afc40da5e56d420f1c0a59f561642bda77f6cee7383f04762bb4f359b5c0/aind_slurm_rest-0.2.0-py3-none-any.whl", hash = "sha256:c80b2ef3746d3532619a0aff00a42da6f08fe1462c214d00dd281ce91acdea1c", size = 358939 },
+    { url = "https://files.pythonhosted.org/packages/d0/3e/660183e9abbaf4704014ec942ec88548719e333fe14597b87bb8d19e4aee/aind_slurm_rest_v2-0.0.3-py3-none-any.whl", hash = "sha256:95e1c9372af440b70f4e50c9651a26659aa3ab6912f94ed43faa327a07836ac5", size = 1128354 },
 ]
 
 [[package]]
@@ -2008,7 +2008,7 @@ version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "aind-data-transfer-service" },
-    { name = "aind-slurm-rest" },
+    { name = "aind-slurm-rest-v2" },
     { name = "cryptography" },
     { name = "np-config" },
     { name = "np-session" },
@@ -2038,7 +2038,7 @@ requires-dist = [
     { name = "aind-codeocean-pipeline-monitor", extras = ["full"], marker = "extra == 'dynamicrouting'", specifier = ">=0.5.0" },
     { name = "aind-data-transfer-service", specifier = ">=1.15.0" },
     { name = "aind-metadata-mapper", marker = "extra == 'dynamicrouting'", specifier = "==0.18.2" },
-    { name = "aind-slurm-rest", specifier = ">=0.1.0,<0.2.1" },
+    { name = "aind-slurm-rest-v2", specifier = "==0.0.3" },
     { name = "bump", marker = "extra == 'dev'", specifier = ">=1.3.2" },
     { name = "cryptography", specifier = "<43.0" },
     { name = "np-config", specifier = ">=0.4.33" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,18 +1,18 @@
 version = 1
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version < '3.11' and platform_system == 'Darwin'",
-    "python_full_version < '3.11' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_system == 'Linux') or (python_full_version < '3.11' and platform_system != 'Darwin' and platform_system != 'Linux')",
-    "python_full_version == '3.11.*' and platform_system == 'Darwin'",
-    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and platform_system == 'Linux') or (python_full_version == '3.11.*' and platform_system != 'Darwin' and platform_system != 'Linux')",
-    "python_full_version == '3.12.*' and platform_system == 'Darwin'",
-    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_system == 'Linux') or (python_full_version == '3.12.*' and platform_system != 'Darwin' and platform_system != 'Linux')",
-    "python_full_version >= '3.13' and platform_system == 'Darwin'",
-    "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
-    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and platform_system == 'Linux') or (python_full_version >= '3.13' and platform_system != 'Darwin' and platform_system != 'Linux')",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version < '3.11' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.11.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 
 [[package]]
@@ -131,6 +131,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/64/02ab3354044f4ad90b2a37efbb5a94282a4d9b23c4cc7ee629bdefede396/aind_data_transfer_models-0.15.0.tar.gz", hash = "sha256:13ed5e15bfd5b4cbf5f8926b0b5e9099c75a6a1d69ba2113570d3252305d9900", size = 48443 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/51/629e0309c71fee63edcfd13ba0cb394843d28ac5be713f88c3ccf9e30b46/aind_data_transfer_models-0.15.0-py3-none-any.whl", hash = "sha256:1f2c9c116d938337a392e70cd3c41b6e0b164a44df36806a16d010b87fdb3dbd", size = 14012 },
+]
+
+[[package]]
+name = "aind-data-transfer-service"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aind-data-schema-models" },
+    { name = "email-validator" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/ae/1aadf237726ac401ea8db334d7ad060b1e8736f860df0a9bee6ce5e31e81/aind_data_transfer_service-1.14.0.tar.gz", hash = "sha256:6bc36cde8876f4bb10a79bc9b8397f6360c7da2c7a27b363bf1d9ed9f7fa4b4b", size = 216418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/67/cae2bc324fbd77e6852effd3f0ec74f26ae98a1d1926b163f4c74a86787a/aind_data_transfer_service-1.14.0-py3-none-any.whl", hash = "sha256:1ad574302b51353f249f04f09cb8cf0045caee528b7c637ded71c7ccfc9731f1", size = 45367 },
 ]
 
 [[package]]
@@ -647,7 +662,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -2008,10 +2023,11 @@ wheels = [
 
 [[package]]
 name = "np-codeocean"
-version = "0.3.1"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "aind-data-transfer-models" },
+    { name = "aind-data-transfer-service" },
     { name = "cryptography" },
     { name = "np-config" },
     { name = "np-session" },
@@ -2042,6 +2058,7 @@ requires-dist = [
     { name = "aind-codeocean-pipeline-monitor", extras = ["full"], marker = "extra == 'dynamicrouting'", specifier = ">=0.5.0" },
     { name = "aind-data-transfer-models", specifier = ">=0.15.0" },
     { name = "aind-data-transfer-models", marker = "extra == 'dynamicrouting'", specifier = ">=0.13.1" },
+    { name = "aind-data-transfer-service", specifier = ">=1.14.0" },
     { name = "aind-metadata-mapper", marker = "extra == 'dynamicrouting'", specifier = "==0.18.2" },
     { name = "bump", marker = "extra == 'dev'", specifier = ">=1.3.2" },
     { name = "cryptography", specifier = "<43.0" },
@@ -2809,6 +2826,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/ac/5b1ea50fc08a9df82de7e1771537557f07c2632231bbab652c7e22597908/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909", size = 2822712 },
     { url = "https://files.pythonhosted.org/packages/c4/fc/504d4503b2abc4570fac3ca56eb8fed5e437bf9c9ef13f36b6621db8ef00/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1", size = 2920155 },
     { url = "https://files.pythonhosted.org/packages/b2/d1/323581e9273ad2c0dbd1902f3fb50c441da86e894b6e25a73c3fda32c57e/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567", size = 2959356 },
+    { url = "https://files.pythonhosted.org/packages/08/50/d13ea0a054189ae1bc21af1d85b6f8bb9bbc5572991055d70ad9006fe2d6/psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142", size = 2569224 },
 ]
 
 [[package]]
@@ -3674,7 +3692,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'darwin'",
@@ -2007,6 +2008,7 @@ name = "np-codeocean"
 version = "0.3.3"
 source = { editable = "." }
 dependencies = [
+    { name = "aind-codeocean-pipeline-monitor" },
     { name = "aind-data-transfer-service" },
     { name = "aind-slurm-rest-v2" },
     { name = "cryptography" },
@@ -2021,7 +2023,7 @@ dependencies = [
     { name = "wavpack-numcodecs" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "bump" },
     { name = "pdm" },
@@ -2035,24 +2037,31 @@ dynamicrouting = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aind-codeocean-pipeline-monitor", extras = ["full"], marker = "extra == 'dynamicrouting'", specifier = ">=0.5.0" },
+    { name = "aind-codeocean-pipeline-monitor", specifier = ">=0.5.2" },
     { name = "aind-data-transfer-service", specifier = ">=1.15.0" },
-    { name = "aind-metadata-mapper", marker = "extra == 'dynamicrouting'", specifier = "==0.18.2" },
     { name = "aind-slurm-rest-v2", specifier = "==0.0.3" },
-    { name = "bump", marker = "extra == 'dev'", specifier = ">=1.3.2" },
     { name = "cryptography", specifier = "<43.0" },
     { name = "np-config", specifier = ">=0.4.33" },
     { name = "np-session", specifier = ">=0.6.44" },
     { name = "np-tools", specifier = ">=0.1.23" },
     { name = "npc-ephys", specifier = ">=0.1.32" },
     { name = "npc-lims", specifier = ">=0.1.168" },
-    { name = "npc-lims", marker = "extra == 'dynamicrouting'", specifier = ">=0.1.154" },
     { name = "npc-session", specifier = ">=0.1.34" },
-    { name = "npc-sessions", marker = "extra == 'dynamicrouting'", specifier = ">=0.0.253" },
-    { name = "pdm", marker = "extra == 'dev'", specifier = ">=2.4.9" },
     { name = "polars", specifier = ">=0.20.16" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "wavpack-numcodecs", specifier = "<0.2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bump", specifier = ">=1.3.2" },
+    { name = "pdm", specifier = ">=2.4.9" },
+]
+dynamicrouting = [
+    { name = "aind-codeocean-pipeline-monitor", extras = ["full"], specifier = ">=0.5.0" },
+    { name = "aind-metadata-mapper", specifier = "==0.18.2" },
+    { name = "npc-lims", specifier = ">=0.1.154" },
+    { name = "npc-sessions", specifier = ">=0.0.253" },
 ]
 
 [[package]]


### PR DESCRIPTION
closes #17

aind-data-transfer-service v2 has a new job submission endpoint and also require v2 job models. V1 endpoints, aind-data-transfer-models, and aind-slurm-rest are being deprecated.

This PR:
- Updates the submission endpoint to `http://aind-data-transfer-service/api/v2/submit_jobs`
- Updates utils to create v2 upload job models (`UploadJobConfigsV2` and `SubmitJobRequestV2`)
     - Refactor to create upload jobs directly from params (no need to create csv first)
     - Default ephys compression settings created using `aind-slurm-rest-v2`
- Removes `aind-data-transfer-models` dependency